### PR TITLE
feat: try to get all reference values from trie.

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -481,3 +481,17 @@ fn clone() {
 
     assert_eq!(t1, t2);
 }
+
+#[test]
+fn test_get_values() {
+    let trie = test_trie();
+    
+    let values: Vec<&u32> = trie.get_values();
+
+    assert_eq!(values.len(), TEST_DATA.len());
+
+    let expected_values: HashSet<u32> = TEST_DATA.iter().map(|&(_, val)| val).collect();
+    let values_set: HashSet<u32> = values.into_iter().cloned().collect();
+
+    assert_eq!(expected_values, values_set);
+}

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -167,6 +167,14 @@ where
     {
         self.get_ancestor(key).and_then(|t| t.node.value())
     }
+    
+    ///  Get all values references in the trie.
+    /// 
+    /// The values are returned in no particular order.
+    #[inline]
+    pub fn get_values<'a>(&'a self) -> Vec<&'a V> {
+        self.node.as_vec()
+    }
 
     /// The key may be any borrowed form of the trie's key type, but TrieKey on the borrowed
     /// form *must* match those for the key type
@@ -253,5 +261,24 @@ impl<K: TrieKey, V> Default for Trie<K, V> {
     #[inline]
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl<K, V> TrieNode<K, V>
+where
+    K: TrieKey,
+{
+    pub fn as_vec<'a>(&'a self) -> Vec<&'a V> {
+        let mut values = Vec::new();
+
+        if let Some(ref key_value) = self.key_value {
+            values.push(&key_value.value);
+        }
+        for child in self.children.iter().filter_map(|c| c.as_ref()) {
+            let child_values: Vec<&V> = child.as_vec();
+            values.extend(child_values);
+        }
+
+        values
     }
 }


### PR DESCRIPTION
In local radix trie, we want to flush all metadata to remote, so we need to iterate all refer values from trie.

This PR export a function to get values from it.